### PR TITLE
Configure Eleventy includes directory

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,0 +1,3 @@
+module.exports = function (eleventyConfig) {
+  return { dir: { input: "src", layouts: "layouts", includes: "partials" } };
+};

--- a/src/layouts/default.njk
+++ b/src/layouts/default.njk
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="fr" data-theme="auto">
-  {% include "../partials/_head.njk" %}
+  {% include "_head.njk" %}
   <body>
-    {% include "../partials/_header.njk" %}
+    {% include "_header.njk" %}
     <main id="content" role="main">
       {{ content | safe }}
     </main>
-    {% include "../partials/_footer.njk" %} {% include "../partials/_scripts.njk" %}
+    {% include "_footer.njk" %} {% include "_scripts.njk" %}
     {{ scripts | safe }}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add Eleventy configuration to use `src` as input and `partials` for includes
- Simplify default layout include paths

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae30a867d083248aa4d15f773354f4