### PR TITLE
Configure Eleventy for minification

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,0 +1,13 @@
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(require("eleventy-plugin-terser"));
+  eleventyConfig.addPlugin(require("@11ty/eleventy-plugin-postcss"), {
+    plugins: [require("cssnano")]
+  });
+
+  return {
+    dir: {
+      input: "src",
+      output: "build"
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Site web Aux Jardins d'Adrien - paysagiste &amp; maraîcher Vence 06",
   "main": "index.js",
   "scripts": {
-    "build": "eleventy",
+    "build": "NODE_ENV=production eleventy",
     "serve": "eleventy --serve"
   },
   "repository": {
@@ -20,5 +20,10 @@
   "homepage": "https://github.com/antonyferriere/auxjardinsdadrien#readme",
   "dependencies": {
     "@11ty/eleventy": "^3.1.2"
+  },
+  "devDependencies": {
+    "eleventy-plugin-terser": "*",
+    "@11ty/eleventy-plugin-postcss": "*",
+    "cssnano": "*"
   }
 }


### PR DESCRIPTION
## Summary
- add build script that sets `NODE_ENV=production`
- configure Terser and PostCSS with cssnano in Eleventy

## Testing
- `npm run build` *(fails: Error in your Eleventy config file 'eleventy.config.js'. Cannot find module 'eleventy-plugin-terser')*


------
https://chatgpt.com/codex/tasks/task_e_68ae3a155ce08324879aa12dea1273ad