### PR TITLE
Replace html-minifier with html-minifier-terser

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -18,6 +18,20 @@ module.exports = function (eleventyConfig) {
     return content;
   });
 
+  eleventyConfig.addTransform("htmlmin", async (content, path) => {
+    if (
+      process.env.NODE_ENV === "production" &&
+      path.endsWith(".html")
+    ) {
+      return await require("html-minifier-terser").minify(content, {
+        collapseWhitespace: true,
+        removeComments: true,
+        useShortDoctype: true,
+      });
+    }
+    return content;
+  });
+
   eleventyConfig.addPlugin(require("eleventy-plugin-postcss"), {
     plugins: [require("cssnano")],
   });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/antonyferriere/auxjardinsdadrien#readme",
   "dependencies": {
     "@11ty/eleventy": "^3.1.2",
-    "html-minifier": "^4.0.0",
+    "html-minifier-terser": "^6.1.0",
     "terser": "^5.43.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- switch dependency from html-minifier to html-minifier-terser
- minify HTML output with html-minifier-terser in Eleventy config

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-minifier-terser)*
- `npm audit` *(fails: 403 Forbidden - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae55821cf08324b5ce87a704ca9841