### PR TITLE
Link homepage testimonials to Google reviews

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -162,9 +162,13 @@
   <div class="container">
     <h2>Ce que disent nos clients</h2>
     <div class="cards" id="google-reviews"></div>
-    <button id="load-more-reviews" class="btn btn-primary" style="display: none">
-      Voir plus d'avis
-    </button>
+    <a
+      class="btn btn-primary"
+      href="https://search.google.com/local/reviews?placeid=ChIJoTkJZTjVzRIR44HWogEyy_M"
+      target="_blank"
+      rel="noopener"
+      >Voir plus d'avis</a
+    >
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace "Voir plus d'avis" button with a link to Google reviews opening in a new tab.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c57197df048324ba5b3099f169d42b