### PR TITLE
feat: improve social meta tags

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,3 +1,4 @@
 {
-  "url": "https://auxjardinsdadrien.com"
+  "url": "https://auxjardinsdadrien.com",
+  "name": "Aux Jardins d'Adrien"
 }

--- a/src/partials/_head.njk
+++ b/src/partials/_head.njk
@@ -12,7 +12,13 @@
 <meta property="og:description" content="{{ seo.description }}" />
 <meta property="og:image" content="{{ seo.ogImage }}" />
 <meta property="og:url" content="{{ seo.canonical }}" />
+<meta property="og:locale" content="fr_FR" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="{{ site.name }}" />
 <meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{ seo.title }}" />
+<meta name="twitter:description" content="{{ seo.description }}" />
+<meta name="twitter:image" content="{{ seo.ogImage }}" />
 <!-- Icônes -->
 <link rel="icon" type="image/png" href="/icons/favicon-96x96.png" sizes="96x96" />
 <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />


### PR DESCRIPTION
## Summary
- add site name to global data for reuse
- expand Open Graph and Twitter meta tags to include locale, site name and image attributes

## Testing
- `npm run build` *(fails: eleventy: not found)*
- `npm install` *(fails: ENOTEMPTY directory not empty rename)*
- `npx @11ty/eleventy --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b0f68df88324a7c5d323e3cfcdeb