### PR TITLE
feat: improve SEO metadata

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://auxjardinsdadrien.com",
+  "url": "https://www.auxjardinsdadrien.com",
   "name": "Aux Jardins d'Adrien"
 }

--- a/src/confidentialite.njk
+++ b/src/confidentialite.njk
@@ -5,7 +5,8 @@
     title: "Politique de confidentialité | Aux Jardins d’Adrien",
     description: "Découvrez comment nous protégeons vos données personnelles.",
     canonical: "https://www.auxjardinsdadrien.com/confidentialite",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Confidentialité"
   }
 %}
 

--- a/src/contact.njk
+++ b/src/contact.njk
@@ -6,7 +6,8 @@
     title: "Contact | Aux Jardins d’Adrien, paysagiste à Vence",
     description: "Demandez un devis ou des informations via notre formulaire de contact.",
     canonical: "https://www.auxjardinsdadrien.com/contact",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Contact"
   }
 %}
 

--- a/src/creation.njk
+++ b/src/creation.njk
@@ -6,7 +6,8 @@
     title: "Création de jardins à Vence | Aux Jardins d’Adrien",
     description: "Conception et aménagement paysager sur mesure adaptés au climat méditerranéen.",
     canonical: "https://www.auxjardinsdadrien.com/creation",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Création"
   }
 %}
 

--- a/src/entretien.njk
+++ b/src/entretien.njk
@@ -5,7 +5,8 @@
     title: "Entretien de jardins à Vence | Aux Jardins d’Adrien",
     description: "Contrats annuels et interventions ponctuelles avec 50 % de crédit d’impôt.",
     canonical: "https://www.auxjardinsdadrien.com/entretien",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Entretien"
   }
 %}
 

--- a/src/estimer.njk
+++ b/src/estimer.njk
@@ -5,7 +5,8 @@
     title: "Estimer votre projet de jardin | Aux Jardins d’Adrien",
     description: "Obtenez une estimation gratuite et rapide pour vos travaux paysagers à Vence.",
     canonical: "https://www.auxjardinsdadrien.com/estimer",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Estimation"
   }
 %}
 

--- a/src/maraichage.njk
+++ b/src/maraichage.njk
@@ -5,7 +5,8 @@
     title: "Maraîchage local à Vence | Aux Jardins d’Adrien",
     description: "Légumes de saison issus d’une micro-ferme en agroécologie et ateliers potagers.",
     canonical: "https://www.auxjardinsdadrien.com/maraichage",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Maraîchage"
   }
 %}
 

--- a/src/mentions-legales.njk
+++ b/src/mentions-legales.njk
@@ -5,7 +5,8 @@
     title: "Mentions légales | Aux Jardins d’Adrien",
     description: "Informations légales du site Aux Jardins d’Adrien, paysagiste à Vence.",
     canonical: "https://www.auxjardinsdadrien.com/mentions-legales",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Mentions légales"
   }
 %}
 

--- a/src/nos-valeurs.njk
+++ b/src/nos-valeurs.njk
@@ -5,7 +5,8 @@
     title: "Nos valeurs | Aux Jardins d’Adrien, paysagiste à Vence",
     description: "Découvrez nos engagements écologiques et notre approche durable du paysagisme.",
     canonical: "https://www.auxjardinsdadrien.com/nos-valeurs",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Nos valeurs"
   }
 %}
 

--- a/src/partials/_head.njk
+++ b/src/partials/_head.njk
@@ -6,11 +6,13 @@
 <meta name="robots" content="{{ seo.robots | default('index, follow') }}" />
 {% if seo.canonical %}
 <link rel="canonical" href="{{ seo.canonical }}" />
+<link rel="alternate" hreflang="fr" href="{{ seo.canonical }}" />
 {% endif %}
 <!-- Open Graph / Twitter -->
 <meta property="og:title" content="{{ seo.title }}" />
 <meta property="og:description" content="{{ seo.description }}" />
 <meta property="og:image" content="{{ seo.ogImage }}" />
+<meta property="og:image:alt" content="{{ seo.ogImageAlt | default(seo.title) }}" />
 <meta property="og:url" content="{{ seo.canonical }}" />
 <meta property="og:locale" content="fr_FR" />
 <meta property="og:type" content="website" />
@@ -19,6 +21,7 @@
 <meta name="twitter:title" content="{{ seo.title }}" />
 <meta name="twitter:description" content="{{ seo.description }}" />
 <meta name="twitter:image" content="{{ seo.ogImage }}" />
+<meta name="twitter:image:alt" content="{{ seo.ogImageAlt | default(seo.title) }}" />
 <!-- Icônes -->
 <link rel="icon" type="image/png" href="/icons/favicon-96x96.png" sizes="96x96" />
 <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />

--- a/src/partials/_scripts.njk
+++ b/src/partials/_scripts.njk
@@ -112,3 +112,25 @@
     }
   }
 </script>
+{% if seo.breadcrumb %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Accueil",
+        "item": "{{ site.url }}"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "{{ seo.breadcrumb }}",
+        "item": "{{ seo.canonical }}"
+      }
+    ]
+  }
+</script>
+{% endif %}

--- a/src/template.njk
+++ b/src/template.njk
@@ -5,7 +5,8 @@
     title: "Titre de page | Aux Jardins d’Adrien",
     description: "Description de la page.",
     canonical: "https://www.auxjardinsdadrien.com",
-    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg"
+    ogImage: "https://www.auxjardinsdadrien.com/images/og-contact.jpg",
+    breadcrumb: "Titre de page"
   }
 %}
 


### PR DESCRIPTION
## Summary
- expose french hreflang and image alt metadata for social sharing
- add breadcrumb structured data and per-page labels
- standardize site URL with www domain

## Testing
- `npm install` *(fails: ENOTEMPTY directory not empty)*
- `npm run build` *(fails: eleventy: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b3e2f65c83249a52f960fe09153e